### PR TITLE
Added check for NSNull pointer types being assigned by json parsing f…

### DIFF
--- a/AutoCoding/AutoCoding.m
+++ b/AutoCoding/AutoCoding.m
@@ -256,7 +256,7 @@ static NSString *const AutocodingException = @"AutocodingException";
         }
         if (object)
         {
-            if (secureSupported && ![object isKindOfClass:propertyClass])
+            if (secureSupported && ![object isKindOfClass:propertyClass] && object != [NSNull null])
             {
                 [NSException raise:AutocodingException format:@"Expected '%@' to be a %@, but was actually a %@", key, propertyClass, [object class]];
             }

--- a/Tests/UnitTests/DataTests.m
+++ b/Tests/UnitTests/DataTests.m
@@ -9,7 +9,6 @@
 #import "TestObject.h"
 #import "AutoCoding.h"
 
-
 @interface DataTests : XCTestCase
 
 @end
@@ -46,6 +45,18 @@
     XCTAssertNotEqual(output.readonlyIntegerWithUnsupportedIvar, input.readonlyIntegerWithUnsupportedIvar);
     XCTAssertNotEqual(output.readonlyIntegerWithPrivateSetter, input.readonlyIntegerWithPrivateSetter);
     XCTAssertNotEqualObjects(output.readonlyDynamicProperty, input.readonlyDynamicProperty);
+}
+
+- (void)testNullObjectRetention {
+    TestObject *input = [[TestObject alloc] init];
+    [input setValue:[NSNull null] forKey:@"publicString"];
+    //save object
+    NSData *data = [NSKeyedArchiver archivedDataWithRootObject:input];
+
+    //load object
+    TestObject *output = [NSKeyedUnarchiver unarchiveObjectWithData:data];
+    XCTAssertEqualObjects(output.publicString, [NSNull null]);
+
 }
 
 - (void)testSecureCoding


### PR DESCRIPTION
…rameworks, if they work alongside autocoding.
Currently we are using AFNetworking JSON parser which gives us [NSNull null] value for null json values. Strings are the only possible candidates in case of jsons, but nested object parsing can also have null pointers different than the standard objective-c nil.
Due to this, de-serialization of older archives was failing in our project.
