### PR TITLE
Updated initWithCoder to correct implementation with proper initializ…

### DIFF
--- a/AutoCoding/AutoCoding.m
+++ b/AutoCoding/AutoCoding.m
@@ -259,7 +259,10 @@ static NSString *const AutocodingException = @"AutocodingException";
 
 - (instancetype)initWithCoder:(NSCoder *)aDecoder
 {
-    [self setWithCoder:aDecoder];
+    self = [self init];
+    if (self) {
+        [self setWithCoder:aDecoder];
+    }
     return self;
 }
 


### PR DESCRIPTION
…er method

The initWithCoder method is missing a call to [self init], so I modified the initWithCoder function to adhere to the standard initializer template.